### PR TITLE
updated setup file to install dependencies for installing from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,18 @@ We propose StableNormal, which tailors the diffusion priors for monocular normal
 
 ![teaser](doc/StableNormal-Teaser.jpg)
 
+
+## Installation:
+
+Please run following commands to build package:
+```
+git clone https://github.com/Stable-X/StableNormal.git
+cd StableNormal
+pip install -r requirements.txt
+```
+or directly build package:
+```
+pip install git+https://github.com/Stable-X/StableNormal.git
+```
+
+

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,31 @@ from pathlib import Path
 from setuptools import setup, find_packages
 
 setup_path = Path(__file__).parent
+README = (setup_path / "README.md").read_text(encoding="utf-8")
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+def split_requirements(requirements):
+    install_requires = []
+    dependency_links = []
+    for requirement in requirements:
+        if requirement.startswith("git+"):
+            dependency_links.append(requirement)
+        else:
+            install_requires.append(requirement)
+
+    return install_requires, dependency_links
+
+with open("./requirements.txt", "r") as f:
+    requirements = f.read().splitlines()
+
+install_requires, dependency_links = split_requirements(requirements)
 
 setup(
     name = "stablenormal",
-    packages=find_packages()
+    packages=find_packages(),
+    description=long_description,
+    long_description=README,
+    install_requires=install_requires
 )


### PR DESCRIPTION
This PR allows user to directly build `StableNormal` package using `pip` via following command line:

`pip install git+https://github.com/Stable-X/StableNormal.git`